### PR TITLE
Use GitHub Actions token to authorize push

### DIFF
--- a/.github/workflows/keyless-sign.yml
+++ b/.github/workflows/keyless-sign.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          password: ${{ github.token }}
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
       - name: Build and Push container images


### PR DESCRIPTION
This alleviates the need to store a personal access token in a secret. The GitHub Action worker is authorized to push packages due to the `packages: write` permission.

(`${{ github.token }}` is effectively an alias for `${{ secrets.GITHUB_TOKEN }}`, see [docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication))