### PR TITLE
Attempt to fix auth error

### DIFF
--- a/.github/workflows/keyless-sign.yml
+++ b/.github/workflows/keyless-sign.yml
@@ -33,7 +33,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/lukehinds/cosign-oidc:${{ github.sha }}
+            ghcr.io/lukehinds/testoidc/cosign-oidc:${{ github.sha }}
       - name: Sign image
         run: |
-          cosign sign ghcr.io/lukehinds/cosign-oidc:${{ github.sha }}
+          cosign sign ghcr.io/lukehinds/testoidc/cosign-oidc:${{ github.sha }}


### PR DESCRIPTION
#7 changed auth from a PAT (you) to the GHA token, which seemingly only has access to push to this repo's packages.